### PR TITLE
remove unused nuget

### DIFF
--- a/source/TuviRestClientLib/TuviRestClientLib.csproj
+++ b/source/TuviRestClientLib/TuviRestClientLib.csproj
@@ -20,13 +20,4 @@
     <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
   </ItemGroup>
   
-  <!-- In current version of BouncyCastle.Cryptography there is a problem with finding interfaces implementations. 
-  So as temporarily solution we use next insertion taken from https://github.com/bcgit/bc-csharp/issues/447 -->
-  <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <Reference Include="BouncyCastle.Cryptography">
-      <HintPath>$(PkgBouncyCastle_Cryptography)\lib\netstandard2.0\BouncyCastle.Cryptography.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
TuviRestClientLib is class library project that doesn't use the BouncyCastle nuget.
We shouldn't add BouncyCastle nuget to all projects

According to https://github.com/bcgit/bc-csharp/issues/447
A ClassLibrary project that uses the BouncyCastle nuget should add:
```xml
 <PackageReference Include="BouncyCastle.Cryptography" Version="2.1.1" />
```
A Console and a Test project that references to the ClassLibrary with the BouncyCastle should add:
```xml
<PackageReference Include="BouncyCastle.Cryptography" Version="2.1.1" ExcludeAssets="Compile" GeneratePathProperty="true" />
  <Reference Include="BouncyCastle.Cryptography">
    <HintPath>$(PkgBouncyCastle_Cryptography)\lib\netstandard2.0\BouncyCastle.Cryptography.dll</HintPath>
</Reference>
```
